### PR TITLE
the field context in CatmashRepository must be declared readonly

### DIFF
--- a/DataRepository/CatmashRepository.cs
+++ b/DataRepository/CatmashRepository.cs
@@ -8,7 +8,7 @@ namespace Catmash.DataRepository
 {
     public class CatmashRepository : ICatmashRepository
     {
-        private CatmashEntities context;
+        private readonly CatmashEntities context;
 
         public CatmashRepository(CatmashEntities context) => this.context = context;
 


### PR DESCRIPTION
It's good practice to declare the fields initialized with DI readonly.