### PR TITLE
Fix: use take and skip instead of select to retrieve row by index

### DIFF
--- a/DataRepository/CatmashRepository.cs
+++ b/DataRepository/CatmashRepository.cs
@@ -35,10 +35,9 @@ namespace Catmash.DataRepository
         public Task<Image> RetrieveAsync(int index)
         {
             return Task.Run<Image>(() => context.Images
-                                                .Select((img, idx) => new { image = img, index = idx })
-                                                .Where(x => x.index == index)
-                                                .Select(x => x.image)
-                                                .SingleOrDefault());
+                                                .Skip(index)
+                                                .Take(1)
+                                                .Single());
         }
 
         public async Task<Image> UpdateAsync(string id, Image image)


### PR DESCRIPTION
The overload of Select that takes index is not yet supported for
EntityFramework Core. Use Skip and Take instead.