### PR TITLE
Add SaveChangesAsync operation to Catmashrepository

### DIFF
--- a/DataRepository/CatmashRepository.cs
+++ b/DataRepository/CatmashRepository.cs
@@ -62,5 +62,12 @@ namespace Catmash.DataRepository
         {
             return Task.Run<int>(() => context.Images.Count());
         }
+
+        public async Task<bool?> SaveChangesAsync()
+        {
+            int affected = await context.SaveChangesAsync();
+            if (affected != 0) return true;
+            else return null;
+        }
     }
 }

--- a/DataRepository/ICatmashRepository.cs
+++ b/DataRepository/ICatmashRepository.cs
@@ -13,5 +13,6 @@ namespace Catmash.DataRepository
         Task<Image> UpdateAsync(string id, Image image);
         Task<bool?> DeleteAsync(string id);
         Task<int> CountAsync();
+        Task<bool?> SaveChangesAsync();
     }
 }

--- a/Tests/AlgorithmsTest/EloRatingCalculatorTest.cs
+++ b/Tests/AlgorithmsTest/EloRatingCalculatorTest.cs
@@ -20,6 +20,7 @@ namespace Catmash.Tests.Algorithms
             // Act
             decimal computedExpectation = ratingCalculator.ComputeExpectation(ratingA, ratingB);
 
+            // Assert
             Assert.Equal(expectation, computedExpectation);
         }
 
@@ -42,6 +43,7 @@ namespace Catmash.Tests.Algorithms
                 actualScore,
                 kFactor);
 
+            // Assert
             Assert.Equal(newRating, computedRating);
         }
     }


### PR DESCRIPTION
When retrieving an entity and make changes to it, it is not possible to update it in the database using DbContext.Update method (unless we detach it). To avoid dealing with detach we expose the ICatmashRepository.SaveChangesAsync method which is a wrapper around DbContext.SaveChangesAsync.