### PR TITLE
Change the PatternedPairGenerator algorithm

### DIFF
--- a/Algorithms/PairGenerator/PatternedPairGenerator.cs
+++ b/Algorithms/PairGenerator/PatternedPairGenerator.cs
@@ -27,7 +27,7 @@ namespace Catmash.Algorithms
             pairNumber %= possiblePairs;
 
             int positionInSlice = pairNumber % (nbElements - 1);
-            int newPairNumber = ((pairNumber + (nbElements - 1) * positionInSlice + 1)) % possiblePairs;
+            int newPairNumber = ((pairNumber + (nbElements - 1) * positionInSlice + (nbElements / 2))) % possiblePairs;
 
             int firstIndex = newPairNumber / (nbElements - 1);
             int secondIndex = newPairNumber % (nbElements - 1);


### PR DESCRIPTION
The new algorithms mimics randomness better. Especially, the
(nbElements/2) quantity in PatternedPairGenerator.GetPair can be set to
any number. It determines the number of pairs between to occurences of a
particulat index. For example, if nbElements/2 is 3, and the 20th pair
is (1,4), you have the guarantee that 1 and 4 won't appear in the 3 next
pairs. Since this change affects only the order in which the pairs are returned,
but still returns all the possible pairs, all the tests still pass.