### PR TITLE
rename CatmashImageController.GetPair action method to GetImagePair

### DIFF
--- a/CatmashWeb/API/CatmashImageController.cs
+++ b/CatmashWeb/API/CatmashImageController.cs
@@ -32,7 +32,7 @@ namespace Catmash.Web.Controllers
 
         [HttpGet("pair")]
         [ProducesResponseType(200, Type = typeof(ImagePair))]
-        public async Task<ImagePair> GetPair()
+        public async Task<ImagePair> GetImagePair()
         {
             var pair = pairGenerator.GetPair(pairNumTracker.NextPair(),
                 await repository.CountAsync());


### PR DESCRIPTION
The name "Pair" refers to the tuples (i, j) that denote the row numbers of
the images in the table Images after sotring by id. The name "ImagePair"
refers to the tuples (image_i, image_j) where image_i is the image at
row i in the table.